### PR TITLE
GET /news の実装(mock)

### DIFF
--- a/backend/ReiwaFakeNews/build.gradle
+++ b/backend/ReiwaFakeNews/build.gradle
@@ -34,6 +34,8 @@ repositories {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime:$serialization_version"
+    implementation "io.ktor:ktor-locations:$ktor_version"
     implementation "io.ktor:ktor-serialization:$ktor_version"
     implementation "io.ktor:ktor-server-netty:$ktor_version"
     implementation "ch.qos.logback:logback-classic:$logback_version"

--- a/backend/ReiwaFakeNews/gradle.properties
+++ b/backend/ReiwaFakeNews/gradle.properties
@@ -3,3 +3,4 @@ kotlin.code.style=official
 kotlin_version=1.3.61
 logback_version=1.2.1
 shadow_version=5.2.0
+serialization_version=0.14.0

--- a/backend/ReiwaFakeNews/src/Application.kt
+++ b/backend/ReiwaFakeNews/src/Application.kt
@@ -1,15 +1,23 @@
 package com.zli
 
+import com.zli.adapter.domain.impl.MockNewsRepository
+import com.zli.adapter.router.getNewsRoute
+import com.zli.usecase.impl.GetNewsUseCaseImpl
 import io.ktor.application.*
 import io.ktor.response.*
-import io.ktor.request.*
 import io.ktor.features.*
 import io.ktor.routing.*
 import io.ktor.http.*
+import io.ktor.locations.KtorExperimentalLocationsAPI
+import io.ktor.locations.Locations
 import io.ktor.serialization.serialization
+import kotlinx.serialization.UnstableDefault
+import kotlinx.serialization.json.Json
 
 fun main(args: Array<String>): Unit = io.ktor.server.netty.EngineMain.main(args)
 
+@UnstableDefault
+@KtorExperimentalLocationsAPI
 @Suppress("unused") // Referenced in application.conf
 @kotlin.jvm.JvmOverloads
 fun Application.module(testing: Boolean = false) {
@@ -19,7 +27,14 @@ fun Application.module(testing: Boolean = false) {
     }
 
     install(ContentNegotiation) {
-        serialization()
+        serialization(json = Json.indented)
+    }
+
+    install(Locations)
+
+    install(Routing) {
+        val getNewsUseCase = GetNewsUseCaseImpl(MockNewsRepository)
+        getNewsRoute(getNewsUseCase)
     }
 
     routing {

--- a/backend/ReiwaFakeNews/src/adapter/domain/impl/MockNewsRepository.kt
+++ b/backend/ReiwaFakeNews/src/adapter/domain/impl/MockNewsRepository.kt
@@ -1,0 +1,27 @@
+package com.zli.adapter.domain.impl
+
+import com.zli.domain.model.News
+import com.zli.domain.repository.NewsRepository
+
+object MockNewsRepository : NewsRepository {
+
+    private val newsList = arrayListOf(
+        News(
+            "ほげほげほげほげ。ほげほげ。ほげほげほげほげ。"
+        ),
+        News(
+            "ほげほげほげほげ。ほげほげ。ほげほげほげほげ。"
+        ),
+        News(
+            "ほげほげほげほげ。ほげほげ。ほげほげほげほげ。"
+        )
+    )
+
+    override suspend fun findRandom(n: Int): List<News> {
+        return newsList.shuffled().subList(0, n)
+    }
+
+    override suspend fun save(news: News) {
+        newsList.add(news)
+    }
+}

--- a/backend/ReiwaFakeNews/src/adapter/router/GetNewsRouter.kt
+++ b/backend/ReiwaFakeNews/src/adapter/router/GetNewsRouter.kt
@@ -1,0 +1,21 @@
+package com.zli.adapter.router
+
+import com.zli.usecase.getnews.GetNewsUseCase
+import io.ktor.application.call
+import io.ktor.http.HttpStatusCode
+import io.ktor.locations.KtorExperimentalLocationsAPI
+import io.ktor.locations.Location
+import io.ktor.locations.get
+import io.ktor.response.respond
+import io.ktor.routing.Route
+
+@KtorExperimentalLocationsAPI
+fun Route.getNewsRoute(getNewsUseCase: GetNewsUseCase) {
+
+    @Location("/news")
+    data class GetNewsRequest(val n: Int = 3)
+    get<GetNewsRequest> { param ->
+        val result = getNewsUseCase.execute(param.n)
+        call.respond(HttpStatusCode.OK, result)
+    }
+}

--- a/backend/ReiwaFakeNews/src/domain/model/News.kt
+++ b/backend/ReiwaFakeNews/src/domain/model/News.kt
@@ -1,0 +1,13 @@
+package com.zli.domain.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class News(
+    val text: String
+) {
+    val tokenizedList: List<String> = text.splitToSequence("。")
+        .filter { it.isNotBlank() }
+        .map { "$it。" }
+        .toList()
+}

--- a/backend/ReiwaFakeNews/src/domain/repository/NewsRepository.kt
+++ b/backend/ReiwaFakeNews/src/domain/repository/NewsRepository.kt
@@ -1,0 +1,9 @@
+package com.zli.domain.repository
+
+import com.zli.domain.model.News
+
+interface NewsRepository {
+    suspend fun findRandom(n: Int): List<News>
+
+    suspend fun save(news: News)
+}

--- a/backend/ReiwaFakeNews/src/usecase/getnews/GetNewsResult.kt
+++ b/backend/ReiwaFakeNews/src/usecase/getnews/GetNewsResult.kt
@@ -1,0 +1,16 @@
+package com.zli.usecase.getnews
+
+import com.zli.domain.model.News
+import kotlinx.serialization.Serializable
+
+sealed class GetNewsResult {
+
+    @Serializable
+    data class Success(val newsList: List<News>) : GetNewsResult()
+
+    @Serializable
+    sealed class Failure(val message: String) : GetNewsResult() {
+        object TooBigGetNewsSize : Failure("指定されたニュースの数が大きすぎます")
+        object NewsSizeRequirePlus : Failure("指定するニュースの数を1以上にしてください")
+    }
+}

--- a/backend/ReiwaFakeNews/src/usecase/getnews/GetNewsUseCase.kt
+++ b/backend/ReiwaFakeNews/src/usecase/getnews/GetNewsUseCase.kt
@@ -1,0 +1,5 @@
+package com.zli.usecase.getnews
+
+interface GetNewsUseCase {
+    suspend fun execute(n: Int = 3): GetNewsResult
+}

--- a/backend/ReiwaFakeNews/src/usecase/impl/GetNewsUseCaseImpl.kt
+++ b/backend/ReiwaFakeNews/src/usecase/impl/GetNewsUseCaseImpl.kt
@@ -1,0 +1,20 @@
+package com.zli.usecase.impl
+
+import com.zli.domain.repository.NewsRepository
+import com.zli.usecase.getnews.GetNewsResult
+import com.zli.usecase.getnews.GetNewsUseCase
+
+class GetNewsUseCaseImpl(
+    private val newsRepository: NewsRepository
+) : GetNewsUseCase {
+
+    override suspend fun execute(n: Int): GetNewsResult {
+        if (n <= 0) return GetNewsResult.Failure.NewsSizeRequirePlus
+        return try {
+            val newsList = newsRepository.findRandom(n)
+            GetNewsResult.Success(newsList)
+        } catch (e: IndexOutOfBoundsException) {
+            GetNewsResult.Failure.TooBigGetNewsSize
+        }
+    }
+}


### PR DESCRIPTION
`GET /news` を叩くと
```JSON
{
    "newsList": [
        {
            "text": "ほげほげほげほげ。ほげほげ。ほげほげほげほげ。",
            "tokenizedList": [
                "ほげほげほげほげ。",
                "ほげほげ。",
                "ほげほげほげほげ。"
            ]
        },
        {
            "text": "ほげほげほげほげ。ほげほげ。ほげほげほげほげ。",
            "tokenizedList": [
                "ほげほげほげほげ。",
                "ほげほげ。",
                "ほげほげほげほげ。"
            ]
        },
        {
            "text": "ほげほげほげほげ。ほげほげ。ほげほげほげほげ。",
            "tokenizedList": [
                "ほげほげほげほげ。",
                "ほげほげ。",
                "ほげほげほげほげ。"
            ]
        }
    ]
}
```

が帰るようにした